### PR TITLE
fixed url ending extension regex to solve issue #1

### DIFF
--- a/lib/SitemapGenerator.js
+++ b/lib/SitemapGenerator.js
@@ -39,7 +39,7 @@ function SitemapGenerator(uri, options) {
     'mp4', 'webm', 'mp3', 'ttf', 'woff', 'json', 'rss', 'atom', 'gz', 'zip',
     'rar', '7z', 'css', 'js', 'gzip', 'exe', 'svg'];
   var exts = exclude.join('|');
-  var extRegex = new RegExp('\.(' + exts + ')', 'i');
+  var extRegex = new RegExp('\\.(' + exts + ')$', 'i');
 
   // throw error if no baseUrl is provided
   if (!uri) {


### PR DESCRIPTION
issue #1 was occurring due to the `extRegex` was matching the extension keywords even in middle of urls.
e.g. this url `http://misterkatiyar.in/javascript/reactive-rxjs-programming.html` will be rejected as it contains keyword `js` which matches to extension `js`.
this causes many urls to be ignored and so those urls are excluded from resulting sitemap.
Updated regex to escape the backslash and added $ sign to make sure it only matches to end of url (ext).
Ref:: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/RegExp