### PR TITLE
exclude rel="nofollow" links from being crawled

### DIFF
--- a/lib/SitemapGenerator.js
+++ b/lib/SitemapGenerator.js
@@ -183,6 +183,12 @@ SitemapGenerator.prototype._discoverResources = function (buffer, queueItem) {
       return null;
     }
 
+    // exclude rel="nofollow" links
+    var rel = $(this).attr('rel');
+    if (/nofollow/i.test(rel)) {
+      return null;
+    }
+
     // remove anchors
     href = href.replace(/(#.*)$/, '');
 


### PR DESCRIPTION
Website crawlers don't follow rel="nofollow" links, and most often they are used in the comment section of websites. Links are often broken there, or point to non-wanted urls, so I think it would be reasonable to exclude them.