### PR TITLE
Fixing error with base tag

### DIFF
--- a/lib/discoverResources.js
+++ b/lib/discoverResources.js
@@ -38,7 +38,10 @@ module.exports = (buffer, queueItem) => {
       const base = $('base').first();
       if (base.length) {
         // base tag is set, prepend it
-        href = url.resolve(base.attr('href'), href);
+        if (base.attr('href') != undefined) {
+          //base tags sometimes don't define href, they somtimes only set with target="_top", target="_blank"
+          href = url.resolve(base.attr('href'), href);
+        }
       }
 
       // handle links such as "./foo", "../foo", "/foo"

--- a/lib/discoverResources.js
+++ b/lib/discoverResources.js
@@ -39,7 +39,7 @@ module.exports = (buffer, queueItem) => {
       if (base.length) {
         // base tag is set, prepend it
         if (base.attr('href') != undefined) {
-          //base tags sometimes don't define href, they somtimes only set with target="_top", target="_blank"
+          //base tags sometimes don't define href, they sometimes they only set target="_top", target="_blank"
           href = url.resolve(base.attr('href'), href);
         }
       }


### PR DESCRIPTION

When there is a relative url, this tool defaults to using the base tag.

However, some websites do not put the base url in their base tag.
ex: `<base target="_blank">`

When base.attr('href') is undefined, a user would get this error:
url.js:87
    throw new TypeError('Parameter "url" must be a string, not ' + typeof url);
  
https://github.com/lgraubner/sitemap-generator-cli/issues/13

Before attempting to resolve the url, just check if href is set. 