### PR TITLE
pass additional options to simplecrawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ Default: `./sitemap.xml`
 
 Filepath for the new sitemap. If multiple sitemaps are created "part_$index" is appended to each filename.
 
+### httpAgent
+
+Type: `HTTPAgent`
+Default: `http.globalAgent`
+
+Controls what HTTP agent to use. This is useful if you want configure HTTP connection through a HTTP/HTTPS proxy (see [http-proxy-agent](https://www.npmjs.com/package/http-proxy-agent)).
+
+### httpsAgent
+
+Type: `HTTPAgent`
+Default: `https.globalAgent`
+
+Controls what HTTPS agent to use. This is useful if you want configure HTTPS connection through a HTTP/HTTPS proxy (see [https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent)).
+
 ### maxEntriesPerFile
 
 Type: `number`  

--- a/lib/createCrawler.js
+++ b/lib/createCrawler.js
@@ -48,6 +48,9 @@ module.exports = (uri, options = {}) => {
   // we don't care about invalid certs
   crawler.ignoreInvalidSSL = true;
 
+  if (options.httpAgent) crawler.httpAgent = options.httpAgent;
+  if (options.httpsAgent) crawler.httpsAgent = options.httpsAgent;
+
   // pass query string handling option to crawler
   crawler.stripQuerystring = options.stripQuerystring;
 


### PR DESCRIPTION
It could be useful for guys who behind proxy like me to set HTTP/HTTPS agent. Although there is `useProxy` option also, but in my case that was not enough to pass the proxy.