### PR TITLE
add queueURL method

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Starts crawler asynchronously and writes sitemap to disk.
 
 Stops the running crawler and halts the sitemap generation.
 
+### queueURL(url)
+
+Add a URL to crawler's queue. Useful to help crawler fetch pages it can't find itself. 
+
 ## Options
 
 You can provide some options to alter the behaviour of the crawler.
@@ -110,14 +114,14 @@ Filepath for the new sitemap. If multiple sitemaps are created "part_$index" is 
 
 ### httpAgent
 
-Type: `HTTPAgent`
+Type: `HTTPAgent`  
 Default: `http.globalAgent`
 
 Controls what HTTP agent to use. This is useful if you want configure HTTP connection through a HTTP/HTTPS proxy (see [http-proxy-agent](https://www.npmjs.com/package/http-proxy-agent)).
 
 ### httpsAgent
 
-Type: `HTTPAgent`
+Type: `HTTPAgent`  
 Default: `https.globalAgent`
 
 Controls what HTTPS agent to use. This is useful if you want configure HTTPS connection through a HTTP/HTTPS proxy (see [https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent)).

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,8 +64,8 @@ module.exports = function SitemapGenerator(uri, opts) {
     crawler.stop();
   };
 
-  const queueURL = (url, referrer) => {
-    crawler.queueURL(url, referrer, false);
+  const queueURL = url => {
+    crawler.queueURL(url, undefined, false);
   };
 
   // create sitemap stream

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,10 @@ module.exports = function SitemapGenerator(uri, opts) {
     crawler.stop();
   };
 
+  const queueURL = (url, referrer) => {
+    crawler.queueURL(url, referrer, false);
+  };
+
   // create sitemap stream
   const sitemap = SitemapRotator(options.maxEntriesPerFile);
 
@@ -157,6 +161,7 @@ module.exports = function SitemapGenerator(uri, opts) {
     getStatus,
     start,
     stop,
+    queueURL,
     on,
     off,
   };


### PR DESCRIPTION
While using your module in my project it was necessary to add URLs manually. It is useful when you have hidden pages on the site which is not visible for crawler. For example, we have _news_ page where data loaded via AJAX. So we made a hidden page with all the news for the crawler to feed. The small wrapper method `queueURL` added in order to help.

If you confirm the PR, I'll append this to README.