### PR TITLE
Adds illegal XML chars escaping & new helper test

### DIFF
--- a/lib/SitemapStream.js
+++ b/lib/SitemapStream.js
@@ -2,6 +2,7 @@ const path = require('path');
 const rand = require('crypto-random-string');
 const os = require('os');
 const fs = require('fs');
+const escapeUnsafe = require('./helpers/escapeUnsafe');
 
 module.exports = function SitemapStream() {
   const tmpPath = path.join(os.tmpdir(), `sitemap_${rand(10)}`);
@@ -15,7 +16,8 @@ module.exports = function SitemapStream() {
   const getPath = () => tmpPath;
 
   const write = url => {
-    stream.write(`\n  <url>\n    <loc>${url}</loc>\n  </url>`);
+    const escapedUrl = escapeUnsafe(url);
+    stream.write(`\n  <url>\n    <loc>${escapedUrl}</loc>\n  </url>`);
   };
 
   const end = () => {

--- a/lib/helpers/__tests__/escapeUnsafe.js
+++ b/lib/helpers/__tests__/escapeUnsafe.js
@@ -1,0 +1,46 @@
+const escapeUnsafe = require('../escapeUnsafe');
+
+test('should be a function', () => {
+  expect(escapeUnsafe).toBeInstanceOf(Function);
+});
+
+test('should escape < characters', () => {
+  const url = 'http://test.com/<>&\'"<>&\'"';
+  const escapedUrl = escapeUnsafe(url);
+
+  expect(url).toMatch(/</);
+  expect(escapedUrl).not.toMatch(/</);
+});
+
+test('should escape > characters', () => {
+  const url = 'http://test.com/<>&\'"<>&\'"';
+  const escapedUrl = escapeUnsafe(url);
+
+  expect(url).toMatch(/>/);
+  expect(escapedUrl).not.toMatch(/>/);
+});
+
+test('should escape & characters', () => {
+  const url = 'http://test.com/<>&\'"<>&\'"';
+  const escapedUrl = escapeUnsafe(url);
+
+  expect(url).toMatch(/&/);
+  // Regex with negative lookahead, matches non escaping &'s
+  expect(escapedUrl).not.toMatch(/&(?!(?:apos|quot|[gl]t|amp);|#)/);
+});
+
+test("should escape ' characters", () => {
+  const url = 'http://test.com/<>&\'"<>&\'"';
+  const escapedUrl = escapeUnsafe(url);
+
+  expect(url).toMatch(/'/);
+  expect(escapedUrl).not.toMatch(/'/);
+});
+
+test('should escape " characters', () => {
+  const url = 'http://test.com/<>&\'"<>&\'"';
+  const escapedUrl = escapeUnsafe(url);
+
+  expect(url).toMatch(/"/);
+  expect(escapedUrl).not.toMatch(/"/);
+});

--- a/lib/helpers/escapeUnsafe.js
+++ b/lib/helpers/escapeUnsafe.js
@@ -1,0 +1,7 @@
+module.exports = unsafe =>
+  unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');


### PR DESCRIPTION
When these XML illegal characters (", ', <, >, &) are present in a URL, the output seems to be invalid XML. This PR aims to fix this case, proper testing for new helper has been added.