### PR TITLE
Add support for basic Http authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ Default: `[]`
 
 If provided, adds a `<priority>` line to each URL in the sitemap. Each value in priorityMap array corresponds with the depth of the URL being added. For example, the priority value given to a URL equals `priorityMap[depth - 1]`. If a URL's depth is greater than the length of the priorityMap array, the last value in the array will be used. Valid values are between `1.0` and `0.0`.
 
+### auth
+
+Type: `string`  
+Default: undefined
+
+If provided, adds a basic Http authentication. Must be provided in the following format: `user:pass`.
+
 ## Events
 
 The Sitemap Generator emits several events which can be listened to.

--- a/src/createCrawler.js
+++ b/src/createCrawler.js
@@ -60,6 +60,12 @@ module.exports = (uri, options = {}) => {
   crawler.initialPath = uri.pathname !== '' ? uri.pathname : '/';
   crawler.initialProtocol = uri.protocol.replace(':', '');
 
+  //Basic Http Authentication. format: user:pass
+  if (options.auth) {
+    crawler.needsAuth = true;
+    crawler.authUser = options.auth.split(':')[0];
+    crawler.authPass = options.auth.split(':')[1];
+  }
   // restrict to subpages if path is provided
   crawler.addFetchCondition(parsedUrl => {
     const initialURLRegex = new RegExp(`${uri.pathname}.*`);


### PR DESCRIPTION
Pass option auth: 'user:pass' to use it.

Added option for crawler to support Basic Http Auth, I think it will be helpful for other users as well.