### PR TITLE
Expose sitemap addURL and ignore conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Controls what HTTPS agent to use. This is useful if you want configure HTTPS con
 
 Apply a test condition to a URL before it's added to the sitemap.
 
-Type: `function`
+Type: `function`  
 Default: `null`
 
 Example:

--- a/README.md
+++ b/README.md
@@ -135,6 +135,24 @@ Default: `https.globalAgent`
 
 Controls what HTTPS agent to use. This is useful if you want configure HTTPS connection through a HTTP/HTTPS proxy (see [https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent)).
 
+### ignore(url)
+
+Apply a test condition to a URL before it's added to the sitemap.
+
+Type: `function`
+Default: `null`
+
+Example:
+
+```JavaScript
+const generator = SitemapGenerator(url, {
+  ignore: url => {
+    // Prevent URLs from being added that contain `<pattern>.
+    return /<pattern>/g.test(url)
+  }
+})
+```
+
 ### ignoreAMP
 
 Type: `boolean`  

--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ crawler.addFetchCondition((queueItem, referrerQueueItem, callback) => {
 });
 ```
 
+### getSitemap()
+
+Returns the sitemap instance (`SitemapRotator`).
+
+This can be useful to add static URLs to the sitemap:
+
+```JavaScript
+const crawler = generator.getCrawler()
+const sitemap = generator.getSitemap()
+
+// Add static URL on crawl init.
+crawler.on('crawlstart', () => {
+  sitemap.addURL('/my/static/url')
+})
+````
+
 ### queueURL(url)
 
 Add a URL to crawler's queue. Useful to help crawler fetch pages it can't find itself.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Example:
 ```JavaScript
 const generator = SitemapGenerator(url, {
   ignore: url => {
-    // Prevent URLs from being added that contain `<pattern>.
+    // Prevent URLs from being added that contain `<pattern>`.
     return /<pattern>/g.test(url)
   }
 })

--- a/src/index.js
+++ b/src/index.js
@@ -169,6 +169,7 @@ module.exports = function SitemapGenerator(uri, opts) {
     start: () => crawler.start(),
     stop: () => crawler.stop(),
     getCrawler: () => crawler,
+    getSitemap: () => sitemap,
     queueURL: url => {
       crawler.queueURL(url, undefined, false);
     },

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,8 @@ module.exports = function SitemapGenerator(uri, opts) {
     lastMod: false,
     changeFreq: '',
     priorityMap: [],
-    ignoreAMP: true
+    ignoreAMP: true,
+    ignore: null
   };
 
   if (!uri) {
@@ -97,6 +98,7 @@ module.exports = function SitemapGenerator(uri, opts) {
     const { url, depth } = queueItem;
 
     if (
+      (opts.ignore && opts.ignore(url)) ||
       /(<meta(?=[^>]+noindex).*?>)/.test(page) || // check if robots noindex is present
       (options.ignoreAMP && /<html[^>]+(amp|⚡)[^>]*>/.test(page)) // check if it's an amp page
     ) {


### PR DESCRIPTION
- Exposes sitemap to allow `addURL` method, this way we can add static links
- Provides an ignore option which conditionally applies a test to a URL before it's added to the sitemap. This is applied on the "fetchcomplete" event.

Here is an example of an implementation:

```
const generator = sg(url, {
  stripQuerystring: false,
  ignore: url => {
    // Prevent query string URLs from being added.
    return (/\?+/g.test(url))
  }
})

const sitemap = generator.getSitemap()
const crawler = generator.getCrawler()

// Fire callback on crawl start.
crawler.on("crawlstart", () => {
  // Add static links.
  statics.map(item => sitemap.addURL(url + item))
})

generator.start()
```