### PR TITLE
Add userAgent option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ Example:
 [1.0, 0.8, 0.6, 0.4, 0.2, 0]
 ```
 
+### userAgent
+
+Type: `string`  
+Default: `Node/SitemapGenerator`
+
+Change the default crawler user agent.
+
 ## Events
 
 The Sitemap Generator emits several events which can be listened to.


### PR DESCRIPTION
I was actually using the module for basic scraping, but needed to supply my own user agent. I realized this is actually an option that can be overridden, but it wasn't documented - so I thought I'd add it!