### PR TITLE
Fix node TLS warning - use ignoreInvalidSSL option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,8 +55,10 @@ module.exports = function SitemapGenerator(uri, opts) {
   // only resolve if sitemap path is truthy (a string preferably)
   const sitemapPath = options.filepath && path.resolve(options.filepath);
 
-  // we don't care about invalid certs
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  // we don't care about invalid certs if ignoreInvalidSSL is set to true
+  if (options.ignoreInvalidSSL) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  }
 
   const crawler = createCrawler(parsedUrl, options);
 


### PR DESCRIPTION
Hello, I noticed that `ignoreInvalidSSL` is not used and there is no way to turn off setting `NODE_TLS_REJECT_UNAUTHORIZED` to `0`