### PR TITLE
Allow user to pass lastMod date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ Default: `false`
 
 Whether to add a `<lastmod>` line to each URL in the sitemap. If present the responses `Last-Modified` header will be used. Otherwise todays date is added.
 
+### lastModFormat
+
+Type: `string`  
+Default: `YYYY-MM-DD`
+
+Format for `<lastmod>` datetime string.
+
+
 ### maxEntriesPerFile
 
 Type: `number`  

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ module.exports = function SitemapGenerator(uri, opts) {
     timeout: 30000,
     decodeResponses: true,
     lastMod: false,
+    lastModFormat: 'YYYY-MM-DD',
     changeFreq: '',
     priorityMap: [],
     ignoreAMP: true,
@@ -109,7 +110,7 @@ module.exports = function SitemapGenerator(uri, opts) {
       if (sitemapPath !== null) {
         // eslint-disable-next-line
         const lastMod = queueItem.stateData.headers['last-modified'];
-        sitemap.addURL(url, depth, lastMod && format(lastMod, 'YYYY-MM-DD'));
+        sitemap.addURL(url, depth, lastMod && format(lastMod, options.lastModFormat));
       }
     }
   });


### PR DESCRIPTION
Allows users to pass a formatting string via the `lastModFormat` option.