### PR TITLE
[NOT BOT] Bump cheerio 1.0.0-rc.2 to 1.0.0-rc.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "async": "2.6.1",
-    "cheerio": "1.0.0-rc.2",
+    "cheerio": "1.0.0-rc.12",
     "cp-file": "6.0.0",
     "crypto-random-string": "1.0.0",
     "date-fns": "1.29.0",


### PR DESCRIPTION
Hi @lgraubner 

Recently I tried to create a sitemap.xml for my personal wiki page using this wonderful open source tool.

However, only one root url was included in sitemap.xml and hyperlinks included in the html body were not added to sitemap.xml.

After some debugging, **I found that the cause of the problem was the version of cheerio.**

My wiki site was composed of open source that supports the latest HTML specifications, and **the old version of cheerio cannot parse the latest HTML tags.**

After upgrading the version of cheerio, my site was finally parsed normally.

You can test it on my site if necessary. https://wiki.yowu.dev

thanks you